### PR TITLE
Fix typo in gpio/deviceplugingpio.cpp

### DIFF
--- a/gpio/deviceplugingpio.cpp
+++ b/gpio/deviceplugingpio.cpp
@@ -23,7 +23,7 @@
 /*!
     \page gpioplugin.html
     \title GPIO Plugin
-    \brief Plugin to controll gpios on different boards.
+    \brief Plugin to control gpios on different boards.
 
     \ingroup plugins
     \ingroup guh-plugins-maker


### PR DESCRIPTION
Replaced "controll" with "control".